### PR TITLE
Potential fix for code scanning alert no. 85: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -813,7 +813,7 @@ def test_smtp():
         success, error = send_email_with_retry(msg, smtp_config)
         if success:
             return jsonify({'message': 'SMTP test OK'}), 200
-        return jsonify({'error': error or 'SMTP test failed'}), 500
+        return jsonify({'error': 'SMTP test failed'}), 500
     except Exception:
         app.logger.exception("SMTP test error")
         return jsonify({'error': 'SMTP test failed'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/Tiritibambix/iTransfer/security/code-scanning/85](https://github.com/Tiritibambix/iTransfer/security/code-scanning/85)

To fix this without changing core behavior, stop returning exception-derived strings in the API response. Keep retry/error handling and logging intact, but always return a generic message to the client when SMTP test fails.

Best single change:
- In `backend/app/routes.py`, inside `test_smtp()` at the failure return after `send_email_with_retry`, replace:
  - `return jsonify({'error': error or 'SMTP test failed'}), 500`
  with:
  - `return jsonify({'error': 'SMTP test failed'}), 500`

This addresses both variants because both taint paths (from `_PermanentSMTPError` and `_TransientSMTPError`) end at that same sink on line 816.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
